### PR TITLE
Fixed Twitter Homework Link

### DIFF
--- a/topic_01_mapreduce/README.md
+++ b/topic_01_mapreduce/README.md
@@ -182,6 +182,6 @@ No late penalty for this lab, and you may collaborate however you'd like.
 
 ## Homework
 
-You should start the [twitter MapReduce](../hw_twitter) homework.
+You should start the [twitter MapReduce](./homework) homework.
 Because this homework can potentially take a very long time to run,
 this homework has a modified due date schedule.


### PR DESCRIPTION
The [original homework link](https://github.com/mikeizbicki/cmc-csci143/blob/2023spring/hw_twitter) resulted in a 404 Error. This PR replaces the broken link with [this link](https://github.com/mikeizbicki/cmc-csci143/tree/2023spring/topic_01_mapreduce/homework), which brings you to the homework directory for topic 1.

Note: I'm assuming that this is where the link is supposed to go, but if I'm wrong please let me know.
