### PR TITLE
Updated late work policy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ You will receive extra credit for pull requests to this repo or any submodule.
 
 **Late Work Policy:**
 
-You lose `2**i` points on every assignment,
+You lose `2**(i-1)` points on every assignment,
 where `i` is the number of days late.
 
 Do not expect partial credit for incomplete assignments.


### PR DESCRIPTION
As noted in the <b>Announcements</b> section of the [Topic 4 SQL README.md file](https://github.com/mikeizbicki/cmc-csci143/tree/2024spring/topic_04_SQL_1), the number of points deducted on late assignments in this course is actually 
```
2**(# days late - 1)
```
rather than 
```
2**(# days late)
``` 
as it is described currently in the <b>Late Work Policy</b> subsection of the <b>Grades</b> section of the [course repository README.md file](https://github.com/mikeizbicki/cmc-csci143).