### PR TITLE
Fixed Vim Capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ You can find the details about the caveat tasks at:
 
 1. You MUST complete all programming assignments on the lambda server.
 
-1. You MUST use either vim or emacs for all text editing.
+1. You MUST use either Vim or Emacs for all text editing.
 
    In particular, you MAY NOT use the GitHub text editor, VSCode, IDLE, or PyCharm for any reason.
 

--- a/future/topic_01_mapreduce/README.md
+++ b/future/topic_01_mapreduce/README.md
@@ -168,7 +168,7 @@ The lab is posted in the [lab-posix-mapreduce submodule](https://github.com/mike
         (It's okay if you don't feel confident in these commands at this point.
         I expect most of the class would benefit from redoing the tutorial.)
 
-1. Spend at least 20 minutes reviewing how to use vim effectively.
+1. Spend at least 20 minutes reviewing how to use Vim effectively.
     You can either:
     
     1. re-do the vimtutor tutorial from last pre-lab, or
@@ -196,7 +196,7 @@ The lab is posted in the [lab-posix-mapreduce submodule](https://github.com/mike
        > **HINT:**
        > Use the `unzip` command to extract the contents of the zip archive;
        > you will have to read the man page in order to figure out the correct option to get the output printed on stdout.
-       > (Use the command `man unzip` to open the manpage, then type the forward slash key `/` to search; `/` is also used the hotkey for searching in vim, firefox, and other open source programs.)
+       > (Use the command `man unzip` to open the manpage, then type the forward slash key `/` to search; `/` is also used the hotkey for searching in Vim, firefox, and other open source programs.)
        > Use the `tr 'A-Z' 'a-z'` command to translate all characters into lowercase.
        > Use `grep` to extract only the lines containing `coronavirus`.
        > Use `wc` to count the number of lines.

--- a/future/topic_01_mapreduce/lab-processes.md
+++ b/future/topic_01_mapreduce/lab-processes.md
@@ -65,7 +65,7 @@ $ chmod a+w /home/username/script.sh
 ```
 again, where `username` is replaced by their real username.
 Now you have write permission on the file,
-and you can edit it in vim.
+and you can edit it in Vim.
 
 **TASK:**
 Change the permissions of your home folder so that other users cannot read the contents of your files.
@@ -208,7 +208,7 @@ but no output is being printed to the screen.
 > (`output` can be replaced with any filename you'd like, and is just an example filename.)
 
 After waiting a few seconds, press `^C` to end the program.
-Now open the `output` file in vim
+Now open the `output` file in Vim
 ```
 $ vim output
 ```
@@ -225,10 +225,10 @@ $ bg
 to run it in the background.
 Now, the `output` file is being continually written to.
 To verify this:
-open the file in vim;
+open the file in Vim;
 check how many lines have been written;
 close the file;
-reopen the file in vim;
+reopen the file in Vim;
 now there should be more lines in the file.
 
 Alternatively, the command `wc -l` shows how many lines are in a file.

--- a/future/topic_03_instagram_tech_stack/README.md
+++ b/future/topic_03_instagram_tech_stack/README.md
@@ -399,9 +399,9 @@ This is a slightly more complicated "hello world" than you did last week that in
     1. the `Dockerfile` for flask contains the command `RUN pip install --upgrade pip`.
        why is this bad?
 
-1. vim copy/paste doesn't work because your clipboard is different from the server's clipboard;
+1. Vim copy/paste doesn't work because your clipboard is different from the server's clipboard;
    need to use the terminal's pasting features;
-   in vim `:set paste`
+   in Vim `:set paste`
    (linux systems have 2 clipboards, the `*` and `+`)
 
 1. docker compose version numbers are wrong in the tutorial; change 3.7 -> 3.3

--- a/topic_00_unix/README.md
+++ b/topic_00_unix/README.md
@@ -43,7 +43,7 @@ We will use docker and docker-compose to manage our own "virtual cloud infrastru
 
 <img src=img/map_of_cs.png width=600px>
 
-All text editing must be done in vim.
+All text editing must be done in Vim.
 We will encounter many instances in this class where more familiar tools like VSCode and Jupyter Notebooks will not work.
 
 Vim is famous for having a steep learning curve,
@@ -59,7 +59,7 @@ and has inspired lots of memes/comics:
 **Cheat sheets:**
 
 1. [bash](https://files.fosswire.com/2007/08/fwunixref.pdf)
-1. [vim](https://github.com/mikeizbicki/ucr-cs100/blob/class-template/textbook/cheatsheets/vim-cheatsheet.pdf)
+1. [Vim](https://github.com/mikeizbicki/ucr-cs100/blob/class-template/textbook/cheatsheets/vim-cheatsheet.pdf)
 1. [git](https://education.github.com/git-cheat-sheet-education.pdf)
 
 <!--
@@ -111,10 +111,10 @@ You won't be able to complete the homework, however, until you've completed all 
    ```
    $ vimtutor
    ```
-   Complete all instructions in order to learn vim.
+   Complete all instructions in order to learn Vim.
    This should take 30-60 minutes.
 
-   1. (optional) There is a videogame-style tutorial for vim at <https://vim-adventures.com/> that you might find more enjoyable.
+   1. (optional) There is a videogame-style tutorial for Vim at <https://vim-adventures.com/> that you might find more enjoyable.
         You are welcome to complete that videogame instead.
         The first three levels are free, but then you must pay $25 for the full game.
 
@@ -147,7 +147,7 @@ You won't be able to complete the homework, however, until you've completed all 
 
     1. [Ken Thompson and Dennis Ritchie Explain UNIX](https://www.youtube.com/watch?v=JoVQTPbD6UY)
     1. (optional) [Where GREP Came From - Computerphile](https://www.youtube.com/watch?v=NTfOnGZUZDk)
-    1. (optional) [vim vs emacs: the oldest rivalry in computing](https://slate.com/technology/2014/05/oldest-software-rivalry-emacs-and-vi-two-text-editors-used-by-programmers.html)
+    1. (optional) [Vim vs Emacs: the oldest rivalry in computing](https://slate.com/technology/2014/05/oldest-software-rivalry-emacs-and-vi-two-text-editors-used-by-programmers.html)
        -->
        
 **Instructions:**
@@ -174,7 +174,7 @@ I will not apply late a late penalty.
 
 **Background Work:**
 
-You will not be able to complete the homework for this week unless you know how to use vim and git.
+You will not be able to complete the homework for this week unless you know how to use Vim and git.
 I recommend everyone complete the following tasks,
 even if you already feel comfortable with these tools.
 


### PR DESCRIPTION
This pr capitalizes all instances of the word Vim in various README's in this repo. vimtutor's spelling is unchanged, as is the vim process, since those both use lowercase in their implementation.

Vim is properly spelled with a capital letter. From [the Vim reference manual's section on pronunciation](https://vimhelp.org/intro.txt.html#pronounce)

> Vim is pronounced as one word, like Jim, not vi-ai-em. It's written with a capital, since it's a name, again like Jim.

Emacs should probably also be capitalized.