### PR TITLE
Fixed Youtube Link (+ discourse on python capitalization in comments)

### DIFF
--- a/caveat_tasks/culture.md
+++ b/caveat_tasks/culture.md
@@ -18,7 +18,7 @@ so you should be able to finish this task in under 8 hours.
 
 **Watching (non-fiction):** (1 point each)
 
-1. *RevolutionOS* (2001), available on [youtube](https://www.youtube.com/watch?v=4vW62KqKJ5A).
+1. *RevolutionOS* (2001), available on [youtube](https://www.youtube.com/watch?v=k0RYQVkQmWU).
    This documentary describes the evolution of Unix and open source software,
    with many interviews of the "founding fathers" of the movement.
 


### PR DESCRIPTION
Like Vim, Python is properly capitalized. Per the [Python Project's Style Guide](https://devguide.python.org/documentation/style-guide/#specific-words)-

> Python
> The name of our favorite programming language is always capitalized.

Technically this is a 'preferred spelling', again from the Style Guide-

> Most of these entities are not assigned any special markup, but the preferred spellings are given in [Specific words](https://devguide.python.org/documentation/style-guide/#specific-words) to aid authors in maintaining the consistency of presentation in the Python documentation.

Also- I found a broken youtube link in the culture caveat and fixed that!