### PR TITLE
Remove broken Triplebyte link and replace with new article

### DIFF
--- a/caveat_tasks/culture.md
+++ b/caveat_tasks/culture.md
@@ -8,7 +8,7 @@ According to [wikipedia](https://en.wikipedia.org/wiki/Hacker_culture),
 > Hacker Culture is a subculture of individuals who enjoy the intellectual challenge of creatively overcoming the limitations of software systems to achieve novel and clever outcomes.
 
 The purpose of this assignment is to ~~brainwash you into the hacker cult~~ introduce you to this hacker culture.
-It will also help you pass the [culture fit test](https://triplebyte.com/blog/what-companies-mean-by-culture-fit) in CS job interviews.
+It will also help you pass the [culture fit test](https://www.linkedin.com/advice/0/what-best-ways-demonstrate-company-culture-fit-during-zcjbe) in CS job interviews.
 
 ## Task
 


### PR DESCRIPTION
Removed the deprecated Triplebyte link in the `culture.md` file, which is no longer available due to the acquisition of Triplebyte by another company. Attempting to access the original link results in the following error:

```
Your connection is not private
Attackers might be trying to steal your information from triplebyte.com (for example, passwords, messages, or credit cards). Learn more about this warning
net::ERR_CERT_COMMON_NAME_INVALID
Turn on enhanced protection to get Chrome's highest level of security
```

I replaced the broken link with a new article available on LinkedIn that discusses culture fit in a programming job interview.