### PR TITLE
Fixed docker-compose to be docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Depends entirely on the person who is talking.
         1. mapreduce
         1. git
         1. continuous integration / test driven development
-        1. docker / docker-compose
+        1. docker / docker compose
         1. (**50% of course**) SQL using sqlite3 / postgres
         1. Instagram tech stack
         1. large language models (LLMs)
@@ -231,7 +231,7 @@ I want you to succeed and I'll make every effort to ensure that you can.
 # topic change
 Need to cover TTY vs non-TTY stdin/stdout in the first 2 weeks of class on bash.
 
-In particular, docker exec defaults to non-TTY and must add -it to get TTY, but docker-compose defaults to TTY and must add -T to get non-tty
+In particular, docker exec defaults to non-TTY and must add -it to get TTY, but docker compose defaults to TTY and must add -T to get non-tty
 
 Properly escape the \x00 in the twitter_postgres assignment
 

--- a/future/topic_13_finalproject/README.md
+++ b/future/topic_13_finalproject/README.md
@@ -39,9 +39,9 @@ The project is worth 32 points total.
 There are 8 required tasks, each worth 4 points.
 
 **Task 1:** The project structure should follow the structure of the [flask-on-docker homework](https://github.com/mikeizbicki/cmc-csci143/tree/2024spring/topic_03_instagram_tech_stack#homework).  In particular:
-1. There should be a development `docker-compose.yml` file with a web service and postgres service.
-1. There should be a production `docker-compose.yml` file with a web service, postgres service, and nginx service.
-1. You should be able to start your web page by running `docker-compose up` with either of these yml files.
+1. There should be a development `docker compose.yml` file with a web service and postgres service.
+1. There should be a production `docker compose.yml` file with a web service, postgres service, and nginx service.
+1. You should be able to start your web page by running `docker compose up` with either of these yml files.
 1. You must have appropriate volumes defined so that bringing the containers down does not delete the database.
 1. You must store all (non-sensitive) project files in a git repo.
     It should be trivial to bring your project up/down from only the files in the repo.

--- a/topic_00_unix/README.md
+++ b/topic_00_unix/README.md
@@ -39,7 +39,7 @@ The lambda server has:
 1. 2 TB NVME mounted on `/` (you have 10GB of space)
 1. 50 TB RAID array of 16 HDDs mounted on `/data` (you have 250GB of space)
 
-We will use docker and docker-compose to manage our own "virtual cloud infrastructure" from the lambda server.
+We will use docker and docker compose to manage our own "virtual cloud infrastructure" from the lambda server.
 
 <img src=img/map_of_cs.png width=600px>
 

--- a/topic_03_instagram_tech_stack/README.md
+++ b/topic_03_instagram_tech_stack/README.md
@@ -1,4 +1,4 @@
-# Docker, docker-compose, the Instagram tech stack
+, docker compose, the Instagram tech stack
 
 ## Announcements
 
@@ -213,7 +213,7 @@
 
     <a href=https://xkcd.com/1988/><img width=600px src=img/containers_2x.png /></a>
 
-    1. docker-compose
+    1. docker compose
 
         1. a convenient "declarative" interface for managing docker commands
 
@@ -229,7 +229,7 @@
            declarative => specify WHAT, the computer figures out HOW
 
            1. adv: easier to use (fewer sharp edges)
-           1. adv: automatically figure out different HOWs depending on the environment (deploying to laptop? lambda server? AWS? Azure?  docker-compose will figure out the details for you)
+           1. adv: automatically figure out different HOWs depending on the environment (deploying to laptop? lambda server? AWS? Azure?  docker compose will figure out the details for you)
            1. dis: less control
            1. dis: works only for docker
 
@@ -237,11 +237,11 @@
 
            <img src=img/galaxy-brain.jpg width=400px />
 
-        1. `docker-compose` used to be a standalone program (written in python)
+        1. `docker compose` used to be a standalone program (written in python)
 
             It has now been integrated directly into `docker` (written in golang)
 
-            This means that wherever you see `docker-compose` in a tutorial, you should substitute `docker compose` without a space
+            This means that wherever you see `docker compose` in a tutorial, you should substitute `docker compose` without a space
 
             See the docker documentation for migration details: <https://docs.docker.com/compose/releases/migrate/>
 
@@ -260,20 +260,20 @@
            > ```
            > Assuming you get output similar to the above, you can now install the program:
            > ```
-           > $ pip3 install docker-compose
-           > $ which docker-compose
-           > /home/user/.local/bin/docker-compose
+           > $ pip3 install docker compose
+           > $ which docker compose
+           > /home/user/.local/bin/docker compose
            > ```
            -->
 
         1. important commands
-            1. `docker-compose build`: builds the container
-            1. `docker-compose up`: start all the services
+            1. `docker compose build`: builds the container
+            1. `docker compose up`: start all the services
                 1. `-d` in deamon mode
-            1. `docker-compose down`: stop all the services (equivalent to `docker stop` and `docker rm`
-            1. `docker-compose exec`: run a command on an already running docker container
-            1. `docker-compose run`: (probably don't want to use this for this class) brings up a container and runs a 1-off command; useful for admin tasks
-            1. `docker-compose logs [container]`: view the logs of `[container]` or all containers if not specified
+            1. `docker compose down`: stop all the services (equivalent to `docker stop` and `docker rm`
+            1. `docker compose exec`: run a command on an already running docker container
+            1. `docker compose run`: (probably don't want to use this for this class) brings up a container and runs a 1-off command; useful for admin tasks
+            1. `docker compose logs [container]`: view the logs of `[container]` or all containers if not specified
                 1. `-f` follow mode
     1. docker volumes
         1. allow "persistent state" in a docker container
@@ -281,10 +281,10 @@
         1. two types of volumes we'll use
             1. bind mounts (you manage where the data is stored)
             1. named volumes (docker manages where the data is stored)
-        1. docker-compose will handle all of the (rather complicated) underlying docker commands for us automatically
+        1. docker compose will handle all of the (rather complicated) underlying docker commands for us automatically
         1. references:
             1. docker's official docs: https://docs.docker.com/storage/volumes/
-            1. good tutorial that also references docker-compose: https://devopsheaven.com/docker/docker-compose/volumes/2018/01/16/volumes-in-docker-compose.html
+            1. good tutorial that also references docker compose: https://devopsheaven.com/docker/docker-compose/volumes/2018/01/16/volumes-in-docker-compose.html
     1. differences between docker image and docker container
         1. image:
             1. defined by a docker file
@@ -298,20 +298,20 @@
                 1. changes do not affect the base image, or any other containers created from the image
         1. remove stopped containers with the command
            ```
-           $ docker-compose rm
+           $ docker compose rm
            ```
            1. the command
               ```
-              $ docker-compose down
+              $ docker compose down
               ```
               is a shortcut for the following two commands
               ```
-              $ docker-compose stop
-              $ docker-compose rm
+              $ docker compose stop
+              $ docker compose rm
               ```
            1. if you choose to just run the `stop` command, then you can restart the non-deleted content by running
               ```
-              $ docker-compose start
+              $ docker compose start
               ```
     1. More Dockerfile 
         1. [overlay filesystems](https://jvns.ca/blog/2019/11/18/how-containers-work--overlayfs/)
@@ -406,9 +406,9 @@ This is a slightly more complicated "hello world" than you did last week that in
     1. production:
         1. to update the contents of your image, run the commands
            ```
-           $ docker-compose -f docker-compose.prod.yml down
-           $ docker-compose -f docker-compose.prod.yml build
-           $ docker-compose -f docker-compose.prod.yml up 
+           $ docker compose -f docker compose.prod.yml down
+           $ docker compose -f docker compose.prod.yml build
+           $ docker compose -f docker compose.prod.yml up 
            ```
            takes a little while, but generates a much faster/more secure image
 -->
@@ -422,7 +422,7 @@ This is a slightly more complicated "hello world" than you did last week that in
 
     see: https://www.ssh.com/ssh/tunneling/example
 
-    docker-compose.yml ports needs to change to 3400:5000 instead of 5000:5000
+    docker compose.yml ports needs to change to 3400:5000 instead of 5000:5000
 
     nginx ports should be 3400:80 NOT 1337:80
 
@@ -446,11 +446,11 @@ This is a slightly more complicated "hello world" than you did last week that in
 
 1. docker compose version numbers are wrong in the tutorial; change 3.7 -> 3.3
 
-    EDIT: instead, pip3 install docker-compose
+    EDIT: instead, pip3 install docker compose
 
 1. sqlalchemy managed vs raw mode
 
-1. for debugging, run `docker-compose up` without the `-d` flag or `docker-compose logs`
+1. for debugging, run `docker compose up` without the `-d` flag or `docker compose logs`
 
 1. psql commands `\l`, `\c`, `\dt`, `\q`
 
@@ -458,9 +458,9 @@ This is a slightly more complicated "hello world" than you did last week that in
 
 1. must understand: `netcat -z` = `nc -z`
 
-1. instructions never use the `docker-compose down` command
+1. instructions never use the `docker compose down` command
 
-1. the volumes in the docker-compose.yml file lets us modify the source code locally without rebuilding the docker images
+1. the volumes in the docker compose.yml file lets us modify the source code locally without rebuilding the docker images
 
 1. postgres docker container must have usernames/passwords specified
 


### PR DESCRIPTION
As we've discussed in class, `docker-compose` has been deprecated and now the proper syntax is `docker compose`. This pr replaces all improper instances of the former with the latter.

This syntax issue is a much bigger problem with all the lab repos, since they reference `docker-compose` substantially more.

I might go and fix all of them at some point if I have enough free time but if someone else wants to do it for me that'd be great. Here's something that'll save you time.

This command will find all instances of `docker-compose` in files we care about.

```
$ grep -r 'docker-compose' --include="*.md" .
```

And this replaces all of those with `docker compose`

```
$ find . -name "*.md" -type f -exec sed -i '' 's/docker-compose/docker compose/g' {} \;
```

Now the only thing you need to do is go back and fix back all proper instances of `docker-compose` (mostly in URLs and such).